### PR TITLE
store type in vxbuilder/vxconsumer builder

### DIFF
--- a/lib/src/vxstate.dart
+++ b/lib/src/vxstate.dart
@@ -9,7 +9,7 @@ part 'vxmutation.dart';
 /// VxWidgetBuilder gives context and status back.
 /// Status are more useful when you use vx effects
 typedef VxStateWidgetBuilder<T> = Widget Function(
-    BuildContext context, dynamic store, VxStatus? status);
+    BuildContext context, T store, VxStatus? status);
 
 /// Status about the current state
 // ignore: public_member_api_docs


### PR DESCRIPTION
In the VxStateWidgetBuilder<T> T is the store type and it is not being used in the method, It is a small change that allows the builder in the widgets in vxbuilder and vxconsumer to nativelly use the type.
